### PR TITLE
Explore progress

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Notist",
   "description": "Annotate websites and online articles",
-  "version": "1.1.4",
+  "version": "1.1.6",
   "icons": {
     "16": "favicon-16.png",
     "48": "favicon-48.png",

--- a/src/content.js
+++ b/src/content.js
@@ -137,6 +137,13 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     const event = document.createEvent('Event');
     event.initEvent('explore_done');
     document.dispatchEvent(event);
+  } else if (request.type === 'EXPLORE_PROGRESS') {
+    const event = new CustomEvent('explore_progress', {
+      detail: {
+        progress: request.message,
+      },
+    });
+    document.dispatchEvent(event);
   }
 });
 

--- a/src/explore.js
+++ b/src/explore.js
@@ -24,8 +24,10 @@ export const exploreSetup = () => {
 };
 
 export const exploreResponse = (type, message) => {
-  chrome.tabs.query({ active: true, url: 'https://*/explore*' }, (tabs) => {
-    chrome.tabs.sendMessage(tabs[0].id, { type, message });
+  chrome.tabs.query({ active: true, url: exploreHost }, (tabs) => {
+    if (tabs.length > 0) {
+      chrome.tabs.sendMessage(tabs[0].id, { type, message });
+    }
   });
 };
 

--- a/src/explore.js
+++ b/src/explore.js
@@ -35,6 +35,7 @@ function politechoDone() {
 
 function politechoProgress() {
   console.log('progress', arguments);
+  exploreResponse('EXPLORE_PROGRESS', arguments);
 }
 
 export const initializeExplore = (friends) => {


### PR DESCRIPTION
**Changes:**
* Send explore progress to frontend with a custom event
* **Hide sidebar by default on all of notist - EXPLORE WILL STILL WORK IF THE SIDEBAR IS HIDDEN BUT NOT DISABLED**
  * We don't want to completely disable the extension on all routes other than explore; we just want to hide the sidebar. If we completely disabled it, then we would have to reload the entire page whenever someone went to the explore route in order to inject the content script that was previously disabled. That would be bad, so instead I programmatically hide the sidebar on all notist routes - didn't have to change any regex matching in the manifest.